### PR TITLE
Fix sidebar navigation arrow

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -18,12 +18,8 @@ export function MenuItemButton({
   iconSrc,
   isCollapsed,
 }: MenuItemProps) {
-  let iconStyles: string;
-  if (iconSrc === "/icons/arrow-left.svg" && isCollapsed) {
-    iconStyles = `${styles.icon} ${styles.rotate}`;
-  } else {
-    iconStyles = styles.icon;
-  }
+  const doRotate = iconSrc.includes("arrow-left") && isCollapsed ? true : false;
+  const iconStyles = classNames(styles.icon, { [styles.rotate]: doRotate });
 
   return (
     <li className={classNames(styles.listItem, className)}>

--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -18,11 +18,18 @@ export function MenuItemButton({
   iconSrc,
   isCollapsed,
 }: MenuItemProps) {
+  let iconStyles: string;
+  if (iconSrc === "/icons/arrow-left.svg" && isCollapsed) {
+    iconStyles = `${styles.icon} ${styles.rotate}`;
+  } else {
+    iconStyles = styles.icon;
+  }
+
   return (
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img className={iconStyles} src={iconSrc} alt={`${text} icon`} />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,7 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.rotate {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
Added a check in menu-item-button.tsx and a rotate class in menu-link-item.module.css.
The .rotate class simply transforms the img by rotating it 180 degrees.
in the menu-item-button.tsx we check to see if we are rendering the arrow-left svg and if the menu is collapsed - if so we add the rotate CSS class to it. 
If not we omit it.