### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -18,9 +18,9 @@ export function MenuItemButton({
   iconSrc,
   isCollapsed,
 }: MenuItemProps) {
-  //look to see if we are rendering the arrow icon : gonna change this
+  //look to see if we are rendering the arrow icon
   const doRotate = iconSrc.includes("arrow-left") && isCollapsed ? true : false;
-  //look to see if the side menu is collapsed
+  //if doRotate is true, rotate the icon
   const iconStyles = classNames(styles.icon, { [styles.rotate]: doRotate });
 
   return (

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import { Routes } from "@config/routes";
 import classNames from "classnames";
 import { NavigationContext } from "./navigation-context";
@@ -20,6 +20,25 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isMobileView, setIsMobileView] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 1024) {
+        setIsMobileView(true);
+      } else {
+        setIsMobileView(false);
+      }
+    };
+    handleResize();
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   return (
     <div
       className={classNames(
@@ -37,9 +56,11 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
+              isMobileView
+                ? "/icons/logo-large.svg"
+                : isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
             }
             alt="logo"
             className={styles.logo}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -83,7 +83,12 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => window.open("mailto:support@prolog.com", "_blank")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support Request",
+                  "_blank",
+                )
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Had to add a window event listener in sidebar-navigation.tsx to check when we are hitting the desktop breakpoint.
Id so we short-circuit the img path assignment tenery and set the logo-large.svg.
Should probably abstract the resize listener to a custom hook for use in other spots.